### PR TITLE
Refactor tree visualization to use smooth animations

### DIFF
--- a/simple-tree.html
+++ b/simple-tree.html
@@ -94,7 +94,7 @@
             background-color: #ecf0f1;
             /* Light gray background */
             color: #2c3e50;
-            transition: all 0.3s ease;
+            transition: top 0.5s ease, left 0.5s ease, transform 0.3s ease, background-color 0.3s ease, color 0.3s ease, opacity 0.3s ease;
             z-index: 10;
         }
 
@@ -485,11 +485,11 @@
 
     <script>
         document.addEventListener('DOMContentLoaded', function () {
-            // Draw lines on initial load
-            updateTreeLines();
+            // Draw the initial tree
+            animateNodes();
 
             // Redraw lines on window resize
-            window.addEventListener('resize', updateTreeLines);
+            window.addEventListener('resize', animateNodes);
         });
 
         // Tree data structure matching code.cpp
@@ -674,14 +674,14 @@
             // Add node to tree data structure
             insertNodeInTree(treeData, value);
 
-            // Rebuild and redraw the tree
-            rebuildTreeVisualization();
+            // Animate the tree to show the new node
+            animateNodes();
 
             showResult(`Added node ${value} to the tree.`, "success");
             input.value = '';
         }
 
-        function deleteNode() {
+        async function deleteNode() {
             const input = document.getElementById('nodeValue');
             const value = parseInt(input.value);
 
@@ -695,17 +695,30 @@
                 return;
             }
 
-            // Delete node from tree data structure
-            const deleted = deleteNodeFromTree(treeData, value);
-
-            if (deleted) {
-                // Rebuild and redraw the tree
-                rebuildTreeVisualization();
-                showResult(`Deleted node ${value} from the tree.`, "success");
-            } else {
+            // Use a helper to check for node existence for accurate feedback
+            if (!findNodeInTree(treeData, value)) {
                 showResult(`Node ${value} not found in the tree.`, "error");
+                input.value = '';
+                return;
             }
 
+            const nodeEl = document.querySelector(`.tree-node[data-value="${value}"]`);
+
+            // Animate fade out
+            if (nodeEl) {
+                nodeEl.style.opacity = '0';
+                nodeEl.style.transform = 'scale(0.5)';
+                await sleep(300); // Wait for animation to complete
+                nodeEl.remove(); // Remove from DOM after animation
+            }
+
+            // Delete from data structure
+            deleteNodeFromTree(treeData, value);
+
+            // Animate remaining nodes to new positions
+            animateNodes();
+
+            showResult(`Deleted node ${value} from the tree.`, "success");
             input.value = '';
         }
 
@@ -752,92 +765,106 @@
             return node;
         }
 
-        function rebuildTreeVisualization() {
-            // Clear existing visualization
-            const container = document.getElementById('treeVisualization');
-            container.innerHTML = '';
+        function findNodeInTree(node, value) {
+            if (!node) return null;
+            if (node.data === value) return node;
+            return findNodeInTree(node.left, value) || findNodeInTree(node.right, value);
+        }
 
-            // Create new SVG and nodes based on current tree structure
-            const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-            svg.setAttribute('class', 'tree-svg');
-            svg.setAttribute('viewBox', '0 0 800 400');
-            svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
-
-            // Draw tree recursively
+        function animateNodes() {
             const positions = {};
-            calculatePositions(treeData, 400, 55, 150, positions, 1);
-            drawConnections(treeData, svg, positions);
-            drawNodes(treeData, container, positions);
+            const container = document.getElementById('treeVisualization');
+            const containerRect = container.getBoundingClientRect();
 
-            container.appendChild(svg);
+            calculatePositions(treeData, containerRect.width / 2, 50, containerRect.width / 4, positions);
+
+            const connections = getConnections(treeData);
+            updateTreeLines(connections, positions);
+            drawNodes(treeData, positions);
         }
 
-        function calculatePositions(node, x, y, spacing, positions, id) {
-            if (!node) return id;
-
-            positions[node.data] = { x, y, id: `node-${id}` };
-
-            let nextId = id + 1;
-            if (node.left) {
-                nextId = calculatePositions(node.left, x - spacing, y + 100, spacing * 0.6, positions, nextId);
-            }
-            if (node.right) {
-                nextId = calculatePositions(node.right, x + spacing, y + 100, spacing * 0.6, positions, nextId);
-            }
-
-            return nextId;
-        }
-
-        function drawConnections(node, svg, positions) {
+        function calculatePositions(node, x, y, spacing, positions) {
             if (!node) return;
+            positions[node.data] = { x, y };
+            if (node.left) calculatePositions(node.left, x - spacing, y + 80, spacing / 2, positions);
+            if (node.right) calculatePositions(node.right, x + spacing, y + 80, spacing / 2, positions);
+        }
 
-            const pos = positions[node.data];
+        function getConnections(node) {
+            let connections = [];
+            if (!node) return connections;
 
             if (node.left) {
-                const leftPos = positions[node.left.data];
-                const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-                line.setAttribute('x1', pos.x);
-                line.setAttribute('y1', pos.y);
-                line.setAttribute('x2', leftPos.x);
-                line.setAttribute('y2', leftPos.y);
-                line.setAttribute('stroke', '#333');
-                line.setAttribute('stroke-width', '2');
-                svg.appendChild(line);
-
-                drawConnections(node.left, svg, positions);
+                connections.push({ from: node.data, to: node.left.data });
+                connections = connections.concat(getConnections(node.left));
             }
-
             if (node.right) {
-                const rightPos = positions[node.right.data];
-                const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-                line.setAttribute('x1', pos.x);
-                line.setAttribute('y1', pos.y);
-                line.setAttribute('x2', rightPos.x);
-                line.setAttribute('y2', rightPos.y);
-                line.setAttribute('stroke', '#333');
-                line.setAttribute('stroke-width', '2');
-                svg.appendChild(line);
-
-                drawConnections(node.right, svg, positions);
+                connections.push({ from: node.data, to: node.right.data });
+                connections = connections.concat(getConnections(node.right));
             }
+            return connections;
         }
 
-        function drawNodes(node, container, positions) {
+        function updateTreeLines(connections, positions) {
+            const container = document.getElementById('treeVisualization');
+            // Clear existing lines
+            const existingLines = container.querySelectorAll('.tree-line');
+            existingLines.forEach(line => line.remove());
+
+            connections.forEach(conn => {
+                const fromNode = positions[conn.from];
+                const toNode = positions[conn.to];
+                if (fromNode && toNode) {
+                    const line = document.createElement('div');
+                    line.classList.add('tree-line');
+                    line.id = `line-${conn.from}-to-${conn.to}`;
+
+                    const deltaX = toNode.x - fromNode.x;
+                    const deltaY = toNode.y - fromNode.y;
+                    const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+                    const angle = Math.atan2(deltaY, deltaX) * (180 / Math.PI);
+
+                    line.style.width = `${distance}px`;
+                    line.style.transform = `rotate(${angle}deg)`;
+                    line.style.top = `${fromNode.y}px`;
+                    line.style.left = `${fromNode.x}px`;
+
+                    container.appendChild(line);
+                }
+            });
+        }
+
+
+        function drawNodes(node, positions) {
             if (!node) return;
 
+            const container = document.getElementById('treeVisualization');
+            let nodeEl = document.querySelector(`.tree-node[data-value="${node.data}"]`);
+
+            if (!nodeEl) {
+                nodeEl = document.createElement('div');
+                nodeEl.classList.add('tree-node');
+                nodeEl.setAttribute('data-value', node.data);
+                nodeEl.id = `node-${node.data}`;
+                nodeEl.textContent = node.data;
+                container.appendChild(nodeEl);
+
+                // Start transparent and fade in
+                nodeEl.style.opacity = '0';
+                setTimeout(() => {
+                    nodeEl.style.opacity = '1';
+                }, 10);
+            }
+
             const pos = positions[node.data];
-            const nodeDiv = document.createElement('div');
-            nodeDiv.className = 'tree-node';
-            nodeDiv.id = pos.id;
-            nodeDiv.setAttribute('data-value', node.data);
-            nodeDiv.style.top = `${pos.y - 25}px`;
-            nodeDiv.style.left = `${pos.x - 25}px`;
-            nodeDiv.textContent = node.data;
+            if (pos) {
+                nodeEl.style.top = `${pos.y - 25}px`;
+                nodeEl.style.left = `${pos.x - 25}px`;
+            }
 
-            container.appendChild(nodeDiv);
 
-            if (node.left) drawNodes(node.left, container, positions);
-            if (node.right) drawNodes(node.right, container, positions);
+            if (node.left) drawNodes(node.left, positions);
+            if (node.right) drawNodes(node.right, positions);
         }
 
         function resetTree() {
@@ -900,59 +927,6 @@
             }
         });
 
-        /*
-            EDUCATIONAL NOTE: Dynamic Tree Line Calculation
-
-            The function below dynamically calculates the position and rotation
-            of the lines connecting the tree nodes. This ensures that the
-            visualization remains correct even when the window is resized.
-
-            It works by:
-            1. Getting the coordinates of the parent and child nodes.
-            2. Calculating the distance (length) and angle (rotation) between them.
-            3. Applying these calculations to the line's CSS properties.
-        */
-        function updateTreeLines() {
-            const connections = [
-                { from: 1, to: 2 }, { from: 1, to: 3 },
-                { from: 2, to: 4 }, { from: 2, to: 5 },
-                { from: 3, to: 6 }, { from: 3, to: 7 }
-            ];
-
-            connections.forEach(conn => {
-                const parentEl = document.getElementById(`node-${conn.from}`);
-                const childEl = document.getElementById(`node-${conn.to}`);
-                const lineEl = document.getElementById(`line-${conn.from}-to-${conn.to}`);
-
-                if (parentEl && childEl && lineEl) {
-                    drawConnection(parentEl, childEl, lineEl);
-                }
-            });
-        }
-
-        function drawConnection(parentEl, childEl, lineEl) {
-            const parentRect = parentEl.getBoundingClientRect();
-            const childRect = childEl.getBoundingClientRect();
-            const containerRect = document.getElementById('treeVisualization').getBoundingClientRect();
-
-            // Calculate coordinates relative to the container
-            const parentX = parentRect.left + parentRect.width / 2 - containerRect.left;
-            const parentY = parentRect.top + parentRect.height / 2 - containerRect.top;
-            const childX = childRect.left + childRect.width / 2 - containerRect.left;
-            const childY = childRect.top + childRect.height / 2 - containerRect.top;
-
-            // Calculate distance and angle
-            const deltaX = childX - parentX;
-            const deltaY = childY - parentY;
-            const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-            const angle = Math.atan2(deltaY, deltaX) * (180 / Math.PI);
-
-            // Apply styles to the line element
-            lineEl.style.width = `${distance}px`;
-            lineEl.style.transform = `rotate(${angle}deg)`;
-            lineEl.style.top = `${parentY}px`;
-            lineEl.style.left = `${parentX}px`;
-        }
     </script>
 </body>
 


### PR DESCRIPTION
This commit refactors the binary tree visualization in `simple-tree.html` to use smooth CSS transitions for node additions and deletions, replacing the previous method of rebuilding the entire tree on each change.

Key changes:
- Implemented a new `animateNodes` function to calculate and apply new node positions using CSS transitions.
- Modified the `addNode` and `deleteNode` functions to use the new animation logic, providing a more fluid user experience.
- Added a `findNodeInTree` helper function to improve the reliability of the `deleteNode` function.
- Fixed a crash that occurred during the initial rendering of the tree by replacing an outdated function call with the new animation logic.